### PR TITLE
Issue #24. NullPointerException.

### DIFF
--- a/library/src/main/java/dmax/dialog/SpotsDialog.java
+++ b/library/src/main/java/dmax/dialog/SpotsDialog.java
@@ -71,7 +71,10 @@ public class SpotsDialog extends AlertDialog {
 
     @Override
     public void setMessage(CharSequence message) {
-        ((TextView) findViewById(R.id.dmax_spots_title)).setText(message);
+        this.message = message;
+        if (isShowing()) {
+            initMessage();
+        }
     }
 
     //~


### PR DESCRIPTION
- dmax.dialog.SpotsDialog.setMessage was fixed:
-- we set provided value to the SpotsDialog.message member;
-- if dialog is already displayed we call SpotsDialog.initMessage() logic.