### PR TITLE
Simplify build so that it can build with jitpack instead of deprecated jcenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spots  progress dialog
 
-[![Maven](https://jitpack.io/v/Wheelslabsllc/spots-dialog.svg)](https://jitpack.io/#Wheelslabsllc/spots-dialog)
+[![Maven](https://jitpack.io/v/dybarsky/spots-dialog.svg)](https://jitpack.io/#dybarsky/spots-dialog)
 &nbsp;&nbsp;
 [![Blog Post](https://img.shields.io/badge/medium-post-yellow.svg)](https://medium.com/@dybarsky/spots-progress-dialog-490bd2c737b1)
 &nbsp;&nbsp;
@@ -22,7 +22,7 @@ repositories {
     maven { url "https://jitpack.io" }
 }
 dependencies {
-    implementation "com.github.Wheelslabsllc:spots-dialog:v1.2"
+    implementation "com.github.dybarsky:spots-dialog:v1.2"
 }
 ```
 Javadoc and sources package [classifiers][3] available too.
@@ -183,5 +183,5 @@ Maksym Dybarskyi - http://d-max.info
 [9]: https://github.com/d-max/spots-dialog/releases/tag/v0.4
 [10]: https://github.com/d-max/spots-dialog/releases/tag/v0.7
 [11]: https://github.com/d-max/spots-dialog/releases/tag/v1.1
-[12]: https://github.com/Wheelslabsllc/spots-dialog/releases/tag/v1.2
+[12]: https://github.com/dybarsky/spots-dialog/releases/tag/v1.2
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spots  progress dialog
 
-[![Maven](https://img.shields.io/badge/bintray-1.1-brightgreen.svg)](https://bintray.com/d-max/spots-dialog/d-max.spots-dialog/1.1)
+[![Maven](https://jitpack.io/v/Wheelslabsllc/spots-dialog.svg)](https://jitpack.io/#Wheelslabsllc/spots-dialog)
 &nbsp;&nbsp;
 [![Blog Post](https://img.shields.io/badge/medium-post-yellow.svg)](https://medium.com/@dybarsky/spots-progress-dialog-490bd2c737b1)
 &nbsp;&nbsp;
@@ -19,10 +19,10 @@ Android AlertDialog with moving spots progress indicator packed as android libra
 The library available in maven jcenter repository. You can get it using:
 ```groovy
 repositories {
-    jcenter()
+    maven { url "https://jitpack.io" }
 }
 dependencies {
-    implementation 'com.github.d-max:spots-dialog:1.1@aar'
+    implementation "com.github.Wheelslabsllc:spots-dialog:v1.2"
 }
 ```
 Javadoc and sources package [classifiers][3] available too.
@@ -118,6 +118,9 @@ If you're using proguard, add this code to your rules file:
 
 ### Release notes
 
+**[v1.2, June 11th 2021][12]**
+* Build system updated for JitPack since jcenter is deprecated
+
 **[v1.1, June 5th 2018][11]**
 * Builder provided
 * Small fixes
@@ -180,4 +183,5 @@ Maksym Dybarskyi - http://d-max.info
 [9]: https://github.com/d-max/spots-dialog/releases/tag/v0.4
 [10]: https://github.com/d-max/spots-dialog/releases/tag/v0.7
 [11]: https://github.com/d-max/spots-dialog/releases/tag/v1.1
+[12]: https://github.com/Wheelslabsllc/spots-dialog/releases/tag/v1.2
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,25 +1,25 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.5.1'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
     }
 }
 
 ext {
-    COMPILE_SDK_VERSION = 27
-    MIN_SDK_VERSION = 15
-    TARGET_SDK_VERSION = 27
-
-    LIBRARY_VERSION_NAME = "1.1"
-    LIBRARY_VERSION_CODE = 11
-
-    SAMPLE_VERSION_NAME = "0.1"
-    SAMPLE_VERSION_CODE_LOLLIPOP = 201
-    SAMPLE_VERSION_CODE_KITKAT = 101
-
-    ARTIFACT_ID = "spots-dialog"
+    compileSdkVersion = 30
+    minSdkVersion = 14
+    targetSdkVersion = 30
+    versionCode = 50
+    versionName = "5.0"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Sun Aug 21 21:23:56 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,90 +1,21 @@
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
-
-repositories {
-    google()
-    jcenter()
-}
-
-dependencies {
-    implementation 'com.android.support:support-annotations:27.1.1'
-}
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion MIN_SDK_VERSION
-        targetSdkVersion TARGET_SDK_VERSION
-        versionCode LIBRARY_VERSION_CODE
-        versionName LIBRARY_VERSION_NAME
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode rootProject.ext.versionCode
+        versionName "${rootProject.ext.versionName}"
     }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
     }
-}
-
-task sourcePackage(type: Jar) {
-    baseName = ARTIFACT_ID
-    classifier = "sources"
-    version LIBRARY_VERSION_NAME
-    from android.sourceSets.main.java.srcDirs
-    destinationDir file("$buildDir/artifacts")
-}
-
-task generatePom {
-    doLast {
-        pom {
-            project {
-                groupId "com.github.d-max"
-                artifactId "spots-dialog"
-                version LIBRARY_VERSION_NAME
-                packaging "aar"
-                name "spots progress dialog"
-                description "Android AlertDialog with moving spots progress indicator"
-                url "https://github.com/d-max/spots-dialog"
-                scm {
-                    url "https://github.com/d-max/spots-dialog"
-                    connection "scm:git@github.com:d-max/spots-dialog.git"
-                    developerConnection "scm:git@github.com:d-max/spots-dialog.git"
-                }
-                licenses {
-                    license {
-                        name "MIT License"
-                        url "http://www.opensource.org/licenses/mit-license.php"
-                        distribution "repo"
-                    }
-                }
-                developers {
-                    developer {
-                        id "d-max"
-                        name "Maksym Dybarskyi"
-                        email "maxim.dybarskyy@gmail.com"
-                    }
-                }
-            }
-        }.writeTo("$buildDir/artifacts/${ARTIFACT_ID}-${LIBRARY_VERSION_NAME}.pom")
-    }
-}
-
-task createArtifacts {
-    dependsOn sourcePackage, generatePom
-}
-
-android.libraryVariants.all { variant ->
-    if (variant.buildType.name == "release") {
-        File outDir = file("$buildDir/artifacts")
-        File apkFile = variant.outputs[0].outputFile
-
-        def task = project.tasks.create("copy${variant.name.capitalize()}Aar", Copy)
-        task.from apkFile
-        task.into outDir
-        task.rename apkFile.name, "${ARTIFACT_ID}-${LIBRARY_VERSION_NAME}.aar"
-
-        task.dependsOn variant.assemble
-        task.dependsOn sourcePackage
-        createArtifacts.dependsOn task
+    lintOptions {
+        abortOnError false
     }
 }

--- a/library/src/main/java/dmax/dialog/SpotsDialog.java
+++ b/library/src/main/java/dmax/dialog/SpotsDialog.java
@@ -6,8 +6,6 @@ import android.animation.ObjectAnimator;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.os.Bundle;
-import android.support.annotation.StringRes;
-import android.support.annotation.StyleRes;
 import android.view.View;
 import android.widget.TextView;
 
@@ -36,12 +34,12 @@ public class SpotsDialog extends AlertDialog {
             return this;
         }
 
-        public Builder setMessage(@StringRes int messageId) {
+        public Builder setMessage(int messageId) {
             this.messageId = messageId;
             return this;
         }
 
-        public Builder setTheme(@StyleRes int themeId) {
+        public Builder setTheme(int themeId) {
             this.themeId = themeId;
             return this;
         }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,65 +1,31 @@
 apply plugin: 'com.android.application'
 
-repositories {
-    google()
-    jcenter()
-    maven {
-        url  "https://dl.bintray.com/d-max/spots-dialog"
-    }
-}
-
 android {
-    compileSdkVersion COMPILE_SDK_VERSION
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        versionName SAMPLE_VERSION_NAME
-        targetSdkVersion 27
+        applicationId "com.example.spots.library.demo"
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode rootProject.ext.versionCode
+        versionName "${rootProject.ext.versionName}"
     }
-
-    flavorDimensions "minApi"
-
-    productFlavors {
-        lollipop {
-            minSdkVersion 21
-            versionCode SAMPLE_VERSION_CODE_LOLLIPOP
-            dimension "minApi"
-        }
-        kitkat {
-            minSdkVersion 15
-            versionCode SAMPLE_VERSION_CODE_KITKAT
-            dimension "minApi"
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_6
         targetCompatibility JavaVersion.VERSION_1_6
     }
-
-    signingConfigs {
-        release {
-            storeFile file(System.getProperty("user.home") + "/.android/dmax.keystore")
-            storePassword keystorePassword
-            keyAlias "dmax"
-            keyPassword keystorePassword
-        }
-    }
-
-    buildTypes {
-        release {
-            signingConfig signingConfigs.release
-            minifyEnabled false
-            shrinkResources false
-        }
-    }
-
-    lintOptions {
+    lintOptions{
+        checkReleaseBuilds false
         abortOnError false
-        xmlReport false
-        htmlReport true
-        checkReleaseBuilds true
     }
 }
+
 
 dependencies {
 //    compile 'com.github.d-max:spots-dialog:1.0'


### PR DESCRIPTION
[Jcenter is deprecated](https://developer.android.com/studio/build/jcenter-migration) so it's time to move to another distribution system. [Jitpack](https://jitpack.io) works great and has been around for a long time. Let's use it instead!